### PR TITLE
Fedramp

### DIFF
--- a/source/_additional.html.md.erb
+++ b/source/_additional.html.md.erb
@@ -253,7 +253,6 @@ HTTP status code | Smartsheet errorCode | Smartsheet message
 400 | 1116 | You cannot link a cell to its own sheet.
 400 | 1117 | One of the following cell.hyperlink fields must be non-null: url, sheetId, or reportId.
 400 | 1118 | You cannot set the value of a Gantt allocation column (id {0}) in a row that has child rows.
-500 | 1119 | Failed to complete copy.<br/>**NOTE**: may include a "detail" object containing "topContainerType" and "topContainerId" which represent the top-level folder or workspace that were partially copied.
 400 | 1120 | Too many sheets to copy.<br/>**NOTE**: includes a "detail" object containing "maxSheetCount" which represents the server-side limit on the number of sheets allowed in a single folder/workspace copy operation.
 400 | 1121 | transferTo must be provided because user being deleted owns one or more groups.
 405 | 1122 | Requested URL does not support this method: {0}.
@@ -323,6 +322,7 @@ HTTP status code | Smartsheet errorCode | Smartsheet message
 400 | 1219 | Some recipients cannot be notified. They are not shared to the sheet, or your settings prohibit notification of non-shared users.
 400 | 1220 | Automation action type cannot be changed.
 400 | 1221 | The value {0} is not valid for the attribute action.recipientColumnIds. Only Contact List columns may be used.
+400 | 1255 | Attachment type '{0}' is not supported.
 429 | 4003 | Rate limit exceeded.
 400 | 5xxx | Errors in the 5xxx range represent conditions that a developer cannot reasonably prevent or handle, most typically related to account status. These error messages are localized and can be displayed to the end-user to inform them of the condition that caused the error to occur.
 
@@ -336,6 +336,7 @@ HTTP status code | Smartsheet errorCode | Smartsheet message
 500 | 1012 | Required object attribute(s) are missing from your request: action.includedColumnIds.
 500 | 1031 | The value '[]' is not valid for the attribute action.includedColumnIds.
 500 | 1032 | The attribute(s) automationRule.userCanModify are not allowed for this operation.
+500 | 1119 | Failed to complete copy.<br/>**NOTE**: may include a "detail" object containing "topContainerType" and "topContainerId" which represent the top-level folder or workspace that were partially copied.
 500 | 1170 | The sheet referenced by this widget is unavailable or deleted.
 500 | 1171 | The report referenced by this widget is unavailable or deleted.
 500 | 1172 | The referenced cell is unavailable or deleted.

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -295,7 +295,7 @@ The JSON representation of the objects returned from the List All REST endpoints
 
 ## Working with Smartsheetgov.com Accounts
 
-Smartsheetgov.com is in compliance with FedRAMP standards. As an API developer working on a Smartsheetgov.com account, you should be aware of the following differences from the standard API:
+Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smartsheetgov.com account, you should be aware of the following differences from the standard API:
 
 * The base URL for each API call is smartsheetgov.com instead of smartsheet.com. This documentation uses smartsheet.com in *all* examples. 
 * If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool to help you with this here.

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -301,11 +301,11 @@ Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smarts
 * Smartsheetgov.com has a restriction on attachment types. Only the following attachment types are allowed: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.
 * If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool for each SDK at the following links:
 
-  * C# SDK config changer
-  * Java SDK config changer
-  * Node.js SDK config changer
-  * Python SDK config changer
-  * Ruby SDK config changer
+  * C# SDK [config changer](https://github.com/smartsheet-platform/smartsheet-csharp-sdk)
+  * Java SDK [config changer](https://github.com/smartsheet-platform/smartsheet-java-sdk)
+  * Node.js SDK [config changer](https://github.com/smartsheet-platform/smartsheet-javascript-sdk)
+  * Python SDK [config changer](https://github.com/smartsheet-platform/smartsheet-python-sdk)
+  * Ruby SDK [config changer](https://github.com/smartsheet-platform/smartsheet-ruby-sdk)
 
 ## Versioning and Changes
 

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -299,13 +299,13 @@ Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smarts
 
 * The base URL for each API call is smartsheetgov.com instead of smartsheet.com. This documentation uses smartsheet.com in *all* examples.
 * Smartsheetgov.com has a restriction on attachment types. Only the following attachment types are allowed: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.
-* If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool for each SDK at the following links:
+* If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There are instructions specific to each SDK on how to modify the config file at the following locations:
 
-  * C# SDK [config changer](https://github.com/smartsheet-platform/smartsheet-csharp-sdk)
-  * Java SDK [config changer](https://github.com/smartsheet-platform/smartsheet-java-sdk)
-  * Node.js SDK [config changer](https://github.com/smartsheet-platform/smartsheet-javascript-sdk)
-  * Python SDK [config changer](https://github.com/smartsheet-platform/smartsheet-python-sdk)
-  * Ruby SDK [config changer](https://github.com/smartsheet-platform/smartsheet-ruby-sdk)
+  * [C# SDK](https://github.com/smartsheet-platform/smartsheet-csharp-sdk/blob/master/ADVANCED.md)
+  * [Java SDK](https://github.com/smartsheet-platform/smartsheet-java-sdk)
+  * [Node.js SDK](https://github.com/smartsheet-platform/smartsheet-javascript-sdk)
+  * [Python SDK](https://github.com/smartsheet-platform/smartsheet-python-sdk)
+  * [Ruby SDK](https://github.com/smartsheet-platform/smartsheet-ruby-sdk)
 
 ## Versioning and Changes
 

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -302,10 +302,10 @@ Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smarts
 * If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There are instructions specific to each SDK on how to modify the config file at the following locations:
 
   * [C# SDK](https://github.com/smartsheet-platform/smartsheet-csharp-sdk/blob/master/ADVANCED.md)
-  * [Java SDK](https://github.com/smartsheet-platform/smartsheet-java-sdk)
-  * [Node.js SDK](https://github.com/smartsheet-platform/smartsheet-javascript-sdk)
-  * [Python SDK](https://github.com/smartsheet-platform/smartsheet-python-sdk)
-  * [Ruby SDK](https://github.com/smartsheet-platform/smartsheet-ruby-sdk)
+  * Java SDK -- coming soon
+  * Node.js SDK -- coming soon
+  * Python SDK -- coming soon
+  * Ruby SDK -- coming soon
 
 ## Versioning and Changes
 

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -297,9 +297,15 @@ The JSON representation of the objects returned from the List All REST endpoints
 
 Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smartsheetgov.com account, you should be aware of the following differences from the standard API:
 
-* The base URL for each API call is smartsheetgov.com instead of smartsheet.com. This documentation uses smartsheet.com in *all* examples. 
-* If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool to help you with this here.
+* The base URL for each API call is smartsheetgov.com instead of smartsheet.com. This documentation uses smartsheet.com in *all* examples.
 * Smartsheetgov.com has a restriction on attachment types. Only the following attachment types are allowed: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.
+* If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool for each SDK at the following links:
+
+  * C# SDK config changer
+  * Java SDK config changer
+  * Node.js SDK config changer
+  * Python SDK config changer
+  * Ruby SDK config changer
 
 ## Versioning and Changes
 

--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -293,6 +293,14 @@ Many of the List All commands, for example, `GET /sheets`, return only an abbrev
 
 The JSON representation of the objects returned from the List All REST endpoints will only include a subset of the properties documented here. However, the objects returned from the Java and C# SDKs will represent the omitted properties with NULLs.
 
+## Working with Smartsheetgov.com Accounts
+
+Smartsheetgov.com is in compliance with FedRAMP standards. As an API developer working on a Smartsheetgov.com account, you should be aware of the following differences from the standard API:
+
+* The base URL for each API call is smartsheetgov.com instead of smartsheet.com. This documentation uses smartsheet.com in *all* examples. 
+* If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There is an automated tool to help you with this here.
+* Smartsheetgov.com has a restriction on attachment types. Only the following attachment types are allowed: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.
+
 ## Versioning and Changes
 
 Smartsheet will add new functionality and bug fixes to the API over time. Make sure that your code can handle new JSON properties gracefully. 

--- a/source/_reference-a-f.html.md.erb
+++ b/source/_reference-a-f.html.md.erb
@@ -31,7 +31,7 @@ Attachments can exist on a [comment](#comments) (that is, within a discussion), 
 -----|-----|-----|
 **id** | number | Attachment Id
 **parentId** | number | The Id of the parent 
-**attachmentType** | string | Attachment type (one of <b>BOX_COM</b>, <b>DROPBOX</b>, <b>EGNYTE</b>, <b>EVERNOTE</b>, <b>FILE</b>, <b>GOOGLE_DRIVE</b>, <b>LINK</b>, or <b>ONEDRIVE</b>)
+**attachmentType** | string | Attachment type (one of <b>BOX_COM</b>, <b>DROPBOX*</b>, <b>EGNYTE*</b>, <b>EVERNOTE*</b>, <b>FILE</b>, <b>GOOGLE_DRIVE</b>, <b>LINK</b>, or <b>ONEDRIVE</b>) *Not supported for all account types, see below.
 **attachmentSubType** | string | Attachment sub type, valid only for the following:<ul><li><b>EGNYTE</b> values: <b>FOLDER</b></li><li><b>GOOGLE_DRIVE</b> values: <b>DOCUMENT</b>, <b>DRAWING</b>, <b>PDF</b>, <b>PRESENTATION</b>, or <b>SPREADSHEET</b></li></ul>
 **mimeType** | string | Attachment MIME type (PNG, etc.)
 **parentType** | string | The type of object the attachment belongs to (one of <b>COMMENT</b>, <b>ROW</b>, or <b>SHEET</b>)
@@ -41,6 +41,8 @@ Attachments can exist on a [comment](#comments) (that is, within a discussion), 
 **sizeInKb** | number | The size of the file, if the attachmentType is <b>FILE</b>  
 **url** | string | Attachment temporary URL (files only)
 **urlExpiresInMillis** | number | Attachment temporary URL time to live (files only) 
+
+<aside class="notice">Smartsheetgov.com accounts are restricted to the following attachment types: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.</aside>
 
 ## Post an Attachment
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2019-01-09
+Updated 2019-01-11
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2019-01-23
+Updated 2019-02-01
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2019-01-11
+Updated 2019-01-23
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2018-12-19
+Updated 2019-01-09
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>

--- a/source/snippets/attachURL_table.md.erb
+++ b/source/snippets/attachURL_table.md.erb
@@ -21,3 +21,5 @@ The URL can be any of the following:
 <aside class="notice">For EGNYTE attachments which are folders, the <b>attachmentSubType</b> attribute must be included with a value of <b>FOLDER</b>.</aside>
 
 <aside class="notice">When the attachment type is <b>BOX_COM</b>, <b>DROPBOX</b>, <b>EGNYTE</b> (without an <b>attachmentSubType</b> specified), <b>GOOGLE_DRIVE</b> (without an <b>attachmentSubType</b> specified), or <b>ONEDRIVE</b>, the <b>mimeType</b> is derived by the file extension specified on the <b>name</b> attribute.</aside>
+
+<aside class="notice">Smartsheetgov.com accounts are restricted to the following attachment types: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.</aside>


### PR DESCRIPTION
Changes:
(1) New topic in Intro section: Working with Smartsheetgov.com Accounts (awaiting link to Readme--dependent on some external dev work to be resolved Friday)
(2) Callouts in the Attachments section
(a) Attachment Object
(b) Same language in Attach URL to Comment, Row and Sheet. (other attach topics formatted to just refer to the Attachment Object for details)
(3) New error code 1255.  

