### PR TITLE
Links for SDKs for FedRAMP

### DIFF
--- a/source/_introduction.html.md.erb
+++ b/source/_introduction.html.md.erb
@@ -301,11 +301,11 @@ Smartsheetgov.com is FedRAMP authorized. As an API developer working on a Smarts
 * Smartsheetgov.com has a restriction on attachment types. Only the following attachment types are allowed: BOX_COM, FILE, GOOGLE_DRIVE, LINK, or ONEDRIVE.
 * If you use a Smartsheet SDK, you need to modify the standard config file to point to smartsheetgov.com. There are instructions specific to each SDK on how to modify the config file at the following locations:
 
-  * [C# SDK](https://github.com/smartsheet-platform/smartsheet-csharp-sdk/blob/master/ADVANCED.md)
-  * Java SDK -- coming soon
-  * Node.js SDK -- coming soon
+  * [C# SDK](https://github.com/smartsheet-platform/smartsheet-csharp-sdk/blob/master/ADVANCED.md#working-with-smartsheetgovcom-accounts)
+  * [Java SDK](https://github.com/smartsheet-platform/smartsheet-java-sdk/blob/master/ADVANCED.md#working-with-smartsheetgovcom-accounts)
+  * [Node.js SDK](https://github.com/smartsheet-platform/smartsheet-javascript-sdk#base-url-configuration)
   * Python SDK -- coming soon
-  * Ruby SDK -- coming soon
+  * [Ruby SDK](https://github.com/smartsheet-platform/smartsheet-ruby-sdk#basic-configuration)
 
 ## Versioning and Changes
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2019-02-01
+Updated 2019-02-06
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>


### PR DESCRIPTION
Added new destination for C# including an anchor tag.
Added links for Java, Node.js, and Ruby. Still waiting on Python.