### PR TITLE
ISSUE 101 : Removed "optional" tad from INDEX

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7405,7 +7405,7 @@ curl -o <span class="s2">"stanley_hotel.png"</span> <span class="s2">"https://aw
 </tr>
 <tr>
 <td>Request Body</td>
-<td><a href="#column-object">Column object</a> or an array of Column objects, with the following attributes:<ul><li><strong>title</strong></li><li><strong>type</strong></li><li><strong>autoNumberFormat</strong> (optional)</li><li><strong>description</strong> (optional)</li><li><strong>index</strong> (zero-based, optional)</li><li><strong>locked</strong> (optional)</li><li><strong>options</strong> (optional)</li><li><strong>symbol</strong> (optional)</li><li><strong>systemColumnType</strong> (optional)</li><li><strong>validation</strong> (optional)</li><li><strong>width</strong> (optional)</li></ul></td>
+<td><a href="#column-object">Column object</a> or an array of Column objects, with the following attributes:<ul><li><strong>title</strong></li><li><strong>type</strong></li><li><strong>index</strong> (zero-based)</li><li><strong>autoNumberFormat</strong> (optional)</li><li><strong>description</strong> (optional)</li><li><strong>locked</strong> (optional)</li><li><strong>options</strong> (optional)</li><li><strong>symbol</strong> (optional)</li><li><strong>systemColumnType</strong> (optional)</li><li><strong>validation</strong> (optional)</li><li><strong>width</strong> (optional)</li></ul></td>
 </tr>
 <tr>
 <td>Returns</td>


### PR DESCRIPTION
INDEX is required in the Add Columns report.

Issue link -> https://github.com/smartsheet-platform/api-docs/issues/101

Figured moving it up with the other required ones and removing the "optional" tag worked best.