### PR TITLE
Kevinf june bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # CHANGELOG
 
-Documentation update for April 2020.
+Documentation update for June 2020.
 
-* Fixed Search return to indicate we no longer return row numbers in the contextData field
-* Fixed date/time language to indicate that you should send times in ISO-8601 format as well as how to read the return
-* Fixed error code 1046 to reflect current usage
+* When searching and if a Proof is present, a proofUrl is now returned in the SearchResultItem object.
+* Added a Node.js sample for how to authenticate webhook callbacks.

--- a/source/_reference-g-s.html.md.erb
+++ b/source/_reference-g-s.html.md.erb
@@ -3196,7 +3196,8 @@ Search a specific sheet or search across all sheets that a user can access.
   "results": [
     {
       "contextData": [
-        "Discussion 1"
+        "Discussion 1",
+        "proofUrl: https://......."
     ],
     "objectId": 1888207043356548,
     "objectType": "discussion",
@@ -3225,6 +3226,7 @@ Search a specific sheet or search across all sheets that a user can access.
 **objectType** | string | Search result object type (attachment, discussion, folder, report, row, sheet, Sight, summaryField, template, workspace)
 **parentObjectName** | string | Search result parent object name
 **parentObjectType** | string | Search result parent object type (folder, report, sheet, Sight, template, workspace)
+**proofUrl** | string | The proofUrl string will be present in the contextData if the discussion or attachment belongs to a proof
 **text** | string | Search result text excerpt
 
 ## Search Everything

--- a/source/_webhooks.html.md.erb
+++ b/source/_webhooks.html.md.erb
@@ -276,7 +276,13 @@ The **newWebhookStatus** attribute indicates that the webhook is now enabled.
 ```
 
 ```javascript
-// Not yet implemented
+import { createHmac } from "crypto";
+
+// Calculate a HEX digest from the shared secret + Webhook callback request body string
+const hmac = createHmac("sha256", sharedSecret).update(requestBodyStr).digest("hex");
+
+// Compare HMAC to the Smartsheet-Hmac-SHA256 header value
+const isAuthenticated = hmac === hmacSha256Header;
 ```
 
 ```csharp

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ search: true
 <% USER_AUTO_PROVISIONING_URL = "https://help.smartsheet.com/articles/2072731-user-auto-provisioning-enterprise-only-" %>
 <% WEBHOOKS_INTRO = "Webhooks provide a way for Smartsheet to automatically notify your external application or service when certain events occur in Smartsheet. Webhooks offer a more efficient alternative to using the API to periodically poll for changes." %>
 # <span class="customTOCSectionHeading">Smartsheet API 2.0</span>
-Updated 2020-04-16
+Updated 2020-06-25
 <%= partial "introduction.html.md.erb"%>
 <%= partial "reference-a-f.html.md.erb"%>
 <%= partial "reference-g-s.html.md.erb"%>


### PR DESCRIPTION
* When searching and if a Proof is present, a proofUrl is now returned in the SearchResultItem object.
* Added a Node.js sample for how to authenticate webhook callbacks.