### PR TITLE
fix: a link exists in the deprecated warning message

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2015,7 +2015,7 @@
         <h1 id='smartsheet-api-2-0'><span class="customTOCSectionHeading">Smartsheet API 2.0</span></h1>
 <p>Updated 2021-04-06
 <h1 id='overview'>Overview</h1>
-<aside class="warning">This documentation has been deprecated. While Smartsheet will no longer update this documentation set, it will remain available for a short time while users transition to the new documentation.</aside></p>
+<aside class="warning">This documentation has been deprecated. While Smartsheet will no longer update this documentation set, it will remain available for a short time while users transition to the <a href="http://smartsheet.redoc.ly/">new documentation</a>.</aside></p>
 
 <p>To see Smartsheet’s current developer documentation, go to and bookmark 
 <a href="http://smartsheet.redoc.ly/">Smartsheet API Reference</a>, which now uses OpenAPI for API definitions and object modeling. For feedback, use <a href="https://community.smartsheet.com/categories/api-developers">Smartsheet Community for API Developers</a>.</p>


### PR DESCRIPTION
minor text change to make the link to the new docs location more prominent 